### PR TITLE
Update LLM complexity threshold

### DIFF
--- a/agentic/reasoning/query_analyzer.py
+++ b/agentic/reasoning/query_analyzer.py
@@ -37,6 +37,9 @@ class QueryAnalyzer:
         # Initialize cache for LLM enhancements
         self.cache = SmartCache(config.get("cache", {}))
         self.analysis_cache_ttl = int(config.get("analysis_cache_ttl", 86400))
+        self.llm_complexity_threshold = float(
+            config.get("llm_complexity_threshold", 0.85)
+        )
         
         # Initialize channel resolver
         chromadb_path = config.get("chromadb_path", "./data/chromadb/chroma.sqlite3")
@@ -124,7 +127,7 @@ class QueryAnalyzer:
             analysis["grouped_entities"] = self._group_entities(analysis["entities"])
             
             # Enhance with LLM analysis for complex queries
-            if analysis["complexity"] > 0.7:
+            if analysis["complexity"] > self.llm_complexity_threshold:
                 llm_analysis = await self._llm_enhance_analysis(query, analysis)
                 analysis.update(llm_analysis)
             

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -19,6 +19,7 @@ All core components have been tested and verified:
 export OPENAI_API_KEY="your_openai_api_key_here"
 export DISCORD_TOKEN="your_discord_bot_token_here" 
 export GUILD_ID="your_discord_guild_id_here"
+export LLM_COMPLEXITY_THRESHOLD="0.85"
 ```
 
 ### Python Requirements

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,7 @@ BOT_PREFIX=!
 MAX_RESPONSE_LENGTH=2000
 CACHE_TTL=3600
 ANALYSIS_CACHE_TTL=86400
+LLM_COMPLEXITY_THRESHOLD=0.85
 LOG_LEVEL=INFO
 ```
 
@@ -186,6 +187,7 @@ LOG_LEVEL=INFO
 Located in `agentic/config/modernized_config.py`:
 - **Vector store settings** (embedding model, similarity threshold)
 - **Agent configuration** (timeout, retry logic)
+- **LLM complexity threshold** (`llm_complexity_threshold`)
 - **Performance tuning** (batch sizes, cache limits)
 
 ## 🧪 Testing

--- a/tests/test_query_analysis.py
+++ b/tests/test_query_analysis.py
@@ -19,7 +19,8 @@ async def test_query_analysis():
     # Initialize analyzer
     config = {
         "model": "gpt-4-turbo",
-        "chromadb_path": "./data/chromadb/chroma.sqlite3"
+        "chromadb_path": "./data/chromadb/chroma.sqlite3",
+        "llm_complexity_threshold": 0.85,
     }
     analyzer = QueryAnalyzer(config)
     

--- a/tests/test_time_bound_queries.py
+++ b/tests/test_time_bound_queries.py
@@ -7,7 +7,7 @@ from agentic.reasoning.query_analyzer import QueryAnalyzer
 
 def test_time_bound_queries():
     os.environ['OPENAI_API_KEY'] = 'test-key-for-testing'
-    analyzer = QueryAnalyzer({})
+    analyzer = QueryAnalyzer({"llm_complexity_threshold": 0.85})
     analysis = asyncio.run(analyzer.analyze("show messages from last week"))
     assert analysis['grouped_entities'].get('time_range') is not None
     tr = analysis['grouped_entities']['time_range']


### PR DESCRIPTION
## Summary
- make the LLM enhancement threshold configurable and default to `0.85`
- document the new `LLM_COMPLEXITY_THRESHOLD` environment variable
- mention `llm_complexity_threshold` in system settings
- update tests to use the new threshold
- add `pytest.ini` so archived scripts aren’t collected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea7a86c98832594bd287a5589b07a